### PR TITLE
Removed the code for Auctionator Classic to only use the Auctionator …

### DIFF
--- a/KiwiFarm.lua
+++ b/KiwiFarm.lua
@@ -517,30 +517,18 @@ local GetItemPrice
 do
 	-- auctionator addon
 	local InitAuctionator, Auctionator_GetMarketPrice, Auctionator_GetDisenchantPrice, ItemUpgradeInfo
-	if CLASSIC then -- auctionator for classic
-		function Auctionator_GetMarketPrice(name, itemID)
-			return Atr_GetAuctionPrice(name)
-		end
-		function Auctionator_GetDisenchantPrice(itemLink, class, rarity)
-			return Atr_CalcDisenchantPrice(class, rarity, ItemUpgradeInfo:GetUpgradedItemLevel(itemLink)) -- Atr_GetDisenchantValue() is bugged cannot be used
-		end
-		function InitAuctionator()
-			ItemUpgradeInfo = Atr_GetAuctionPrice and Atr_CalcDisenchantPrice and LibStub('LibItemUpgradeInfo-1.0',true) -- check if auctionator for classic is installed
-		end
-	else -- auctionator for retail
-		local GetAuctionPriceByItemID, GetDisenchantAuctionPrice
-		function Auctionator_GetMarketPrice(name, itemID)
-			return GetAuctionPriceByItemID('KiwiFarm',itemID)
-		end
-		function Auctionator_GetDisenchantPrice(itemLink, class, rarity)
-			return GetDisenchantAuctionPrice(itemLink)
-		end
-		function InitAuctionator()
-			if Auctionator and Auctionator.API and Auctionator.API.v1 then
-				GetAuctionPriceByItemID = Auctionator.API.v1.GetAuctionPriceByItemID
-				GetDisenchantAuctionPrice = Auctionator.Enchant.GetDisenchantAuctionPrice
-				ItemUpgradeInfo = true
-			end
+	local GetAuctionPriceByItemID, GetDisenchantAuctionPrice
+	function Auctionator_GetMarketPrice(name, itemID)
+		return GetAuctionPriceByItemID('KiwiFarm',itemID)
+	end
+	function Auctionator_GetDisenchantPrice(itemLink, class, rarity)
+		return GetDisenchantAuctionPrice(itemLink)
+	end
+	function InitAuctionator()
+		if Auctionator and Auctionator.API and Auctionator.API.v1 then
+			GetAuctionPriceByItemID = Auctionator.API.v1.GetAuctionPriceByItemID
+			GetDisenchantAuctionPrice = Auctionator.Enchant.GetDisenchantAuctionPrice
+			ItemUpgradeInfo = true
 		end
 	end
 	-- aux addon


### PR DESCRIPTION
…Retail code.

I did this because the Auctionator Market Price feature was not working in TBC Classic. This code appears to work, but you should check behind me.